### PR TITLE
Add Vercel deployment support

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,5 @@
+"""Vercel entrypoint for the FastAPI application."""
+from app.main import app as fastapi_app
+
+# Vercel looks for a module-level ``app`` variable to serve ASGI apps.
+app = fastapi_app

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,19 @@ cp .env.example .env   # fill tokens (and API_KEY if you want to protect endpoin
 uvicorn app.main:app --reload --port 8080
 ```
 
+## Deploy (Vercel)
+```bash
+# Install Vercel CLI if you don't already have it
+npm install -g vercel
+
+# First deployment creates the project
+vercel --prod
+```
+
+Environment variables can be configured with `vercel env`. The API will be
+served from the default Serverless Function entrypoint configured in
+`vercel.json`.
+
 ## Deploy (Fly.io)
 ```bash
 chmod +x deploy.sh

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "builds": [
+    {
+      "src": "api/index.py",
+      "use": "@vercel/python"
+    }
+  ],
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.11"
+    }
+  },
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "api/index.py"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel serverless entrypoint that reuses the existing FastAPI application
- configure Vercel routing and runtime via `vercel.json`
- document the workflow for deploying the API with the Vercel CLI

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d937aec1b883298eef60f31b5d29ae