### PR TITLE
Remove Vercel builds config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,4 @@
 {
-  "builds": [
-    {
-      "src": "api/index.py",
-      "use": "@vercel/python"
-    }
-  ],
   "functions": {
     "api/index.py": {
       "runtime": "python3.11"


### PR DESCRIPTION
## Summary
- remove the redundant top-level builds array from `vercel.json`
- rely on the functions configuration to define the Python 3.11 runtime for `api/index.py`

## Testing
- not run (deployment handled outside this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d94459ff7c8329bc81b76bcb3abb4b