### PR TITLE
Fix Vercel runtime version declaration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.py": {
-      "runtime": "python3.11"
+      "runtime": "vercel-python@3.11"
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- update the Vercel function runtime configuration to use an explicit versioned runtime identifier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94821cdc48329870c2e33590da96f