### PR TITLE
Add multi-platform social scoring with Twitter & YouTube support

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,191 @@
+"""Heuristic scoring helpers for social profile signals.
+
+This module centralises the logic that turns a platform-specific signal
+dictionary into a comparable credibility score.  The goal is not to be a
+perfect classifier, but to surface helpful diagnostics that a caller can
+combine with their own business rules.
+
+The scoring intentionally relies on transparent heuristics instead of
+black-box ML models so that users can understand why a profile received a
+particular score.
+"""
+
+from __future__ import annotations
+
+from math import log10
+from typing import Any, Dict, List
+
+
+def _as_int(value: Any) -> int | None:
+    """Best-effort conversion to ``int``.
+
+    The social APIs occasionally return numbers as strings; this helper keeps
+    the scoring code clean by handling those conversions in a single place.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _bounded(value: float, *, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def _log_scale(count: int, *, ceiling_log: float = 6.0) -> float:
+    """Scale large magnitudes into [0, 1] using a logarithmic curve."""
+
+    if count <= 0:
+        return 0.0
+    return _bounded(log10(count + 1) / ceiling_log)
+
+
+def _profile_completeness(signals: Dict[str, Any]) -> tuple[float | None, Dict[str, bool]]:
+    """Estimate profile completeness from commonly available booleans."""
+
+    flags = {
+        "has_bio": bool(signals.get("has_bio")),
+        "has_website": bool(signals.get("has_website")),
+        "profile_picture": bool(
+            signals.get("profile_picture")
+            or signals.get("has_profile_image")
+            or signals.get("has_thumbnail")
+        ),
+        "has_description": bool(signals.get("has_description") or signals.get("about")),
+        "link": bool(signals.get("link")),
+    }
+    present = sum(flags.values())
+    total = len(flags)
+    if total == 0:
+        return None, flags
+    return present / total, flags
+
+
+def _content_count(signals: Dict[str, Any]) -> int | None:
+    for key in ("media_count", "videos", "video_count", "tweets", "posts"):
+        value = _as_int(signals.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def evaluate_signals(platform: str, signals: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a credibility score and contextual diagnostics.
+
+    The result dictionary has the following shape::
+
+        {
+            "score": 0.78,
+            "components": [
+                {"name": "audience_size", "score": 0.52, "weight": 0.25, "context": {...}},
+                ...
+            ],
+            "derived": {...},
+            "flags": ["Account is brand new"],
+        }
+    """
+
+    components: List[Dict[str, Any]] = []
+    flags: List[str] = []
+    derived: Dict[str, Any] = {}
+
+    total_weight = 0.0
+    weighted_score = 0.0
+
+    def add_component(name: str, score: float, weight: float, context: Dict[str, Any]):
+        nonlocal total_weight, weighted_score
+        bounded = _bounded(score)
+        components.append(
+            {
+                "name": name,
+                "score": round(bounded, 3),
+                "weight": round(weight, 3),
+                "context": context,
+            }
+        )
+        total_weight += weight
+        weighted_score += bounded * weight
+
+    # Baseline keeps the final score from being zero when we lack data.
+    add_component("baseline", 0.35, 0.1, {"platform": platform})
+
+    audience = _as_int(
+        signals.get("followers")
+        or signals.get("subscribers")
+        or signals.get("audience")
+    )
+    if audience is not None:
+        audience_score = _log_scale(audience)
+        add_component("audience_size", audience_score, 0.25, {"audience": audience})
+        derived["audience_size"] = audience
+        if audience < 50:
+            flags.append("Audience size is extremely small")
+
+    following = _as_int(signals.get("following"))
+    if audience is not None and following is not None and following > 0:
+        ratio = audience / following
+        derived["follower_following_ratio"] = round(ratio, 2)
+        if ratio < 0.5:
+            flags.append("Followers-to-following ratio is unusually low")
+        elif ratio > 50:
+            flags.append("Followers-to-following ratio is unusually high")
+        if ratio < 0.5:
+            ratio_score = ratio / 0.5
+        elif ratio > 3:
+            ratio_score = min(1.0, 3.0 / ratio)
+        else:
+            ratio_score = 1.0
+        add_component("follower_ratio", ratio_score, 0.15, {"ratio": round(ratio, 3)})
+
+    account_age_days = _as_int(signals.get("account_age_days"))
+    if account_age_days is not None and account_age_days >= 0:
+        derived["account_age_days"] = account_age_days
+        age_score = _bounded(account_age_days / 3650.0)  # 10 years => full score
+        add_component("account_age", age_score, 0.2, {"days": account_age_days})
+        if account_age_days < 90:
+            flags.append("Account is very new")
+
+    profile_score, profile_flags = _profile_completeness(signals)
+    derived["profile_fields"] = profile_flags
+    if profile_score is not None:
+        add_component(
+            "profile_completeness",
+            profile_score,
+            0.15,
+            {"completed_fields": sum(profile_flags.values()), "total_fields": len(profile_flags)},
+        )
+        if profile_score < 0.4:
+            flags.append("Profile is missing important details")
+
+    verified = signals.get("verified")
+    if verified is not None:
+        add_component(
+            "verification",
+            1.0 if bool(verified) else 0.2,
+            0.15,
+            {"verified": bool(verified)},
+        )
+
+    content = _content_count(signals)
+    if content is not None:
+        derived["content_count"] = content
+        content_score = _log_scale(max(content, 0), ceiling_log=5.0)
+        add_component("content_volume", content_score, 0.1, {"count": content})
+        if content < 5:
+            flags.append("Very little posted content")
+
+    score = weighted_score / total_weight if total_weight else 0.0
+    return {
+        "score": round(score, 3),
+        "components": components,
+        "derived": derived,
+        "flags": flags,
+    }
+

--- a/app/normalize.py
+++ b/app/normalize.py
@@ -1,10 +1,15 @@
 from typing import Any, Dict
 
+from .metrics import evaluate_signals
+
+
 def norm_ok(platform: str, raw: Dict[str, Any], signals: Dict[str, Any]) -> Dict[str, Any]:
+    metrics = evaluate_signals(platform, signals)
     return {
         "ok": True,
         "platform": platform,
         "signals": signals,
+        "metrics": metrics,
         "raw": raw,
     }
 

--- a/app/social.py
+++ b/app/social.py
@@ -1,17 +1,34 @@
-import os, httpx
+import os
+from datetime import datetime, timezone
+
+import httpx
 from fastapi import HTTPException
+
 from .normalize import norm_ok, error_json
 
 IG_ACCESS_TOKEN = os.getenv("IG_ACCESS_TOKEN", "")
 FB_ACCESS_TOKEN = os.getenv("FB_ACCESS_TOKEN", "")
 TT_ACCESS_TOKEN = os.getenv("TT_ACCESS_TOKEN", "")
+X_BEARER_TOKEN = os.getenv("X_BEARER_TOKEN", "") or os.getenv("TWITTER_BEARER_TOKEN", "")
+YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY", "")
 
 def TOKENS_STATE():
     return {
         "instagram": bool(IG_ACCESS_TOKEN),
         "facebook": bool(FB_ACCESS_TOKEN),
         "tiktok": bool(TT_ACCESS_TOKEN),
+        "twitter": bool(X_BEARER_TOKEN),
+        "youtube": bool(YOUTUBE_API_KEY),
     }
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
 
 async def fetch_instagram(user_id: str|None, username: str|None, timeout: float):
     if not IG_ACCESS_TOKEN:
@@ -80,4 +97,111 @@ async def fetch_tiktok(username: str, timeout: float):
         "videos": account.get("video_count"),
         "verified": account.get("is_verified"),
         "has_bio": bool(account.get("bio")),
+    })
+
+
+async def fetch_twitter(username: str | None, user_id: str | None, timeout: float):
+    if not X_BEARER_TOKEN:
+        return error_json(501, "twitter not configured (X_BEARER_TOKEN missing)")
+    if not username and not user_id:
+        return error_json(400, "missing username or user_id")
+
+    headers = {"Authorization": f"Bearer {X_BEARER_TOKEN}"}
+    params = {
+        "user.fields": "created_at,description,public_metrics,verified,protected,profile_image_url",
+    }
+    if user_id:
+        url = f"https://api.twitter.com/2/users/{user_id}"
+    else:
+        url = f"https://api.twitter.com/2/users/by/username/{username}"
+
+    async with httpx.AsyncClient(timeout=timeout, headers=headers) as cx:
+        r = await cx.get(url, params=params)
+    if r.status_code != 200:
+        return error_json(r.status_code, f"twitter api error: {r.text[:300]}")
+
+    data = (r.json() or {}).get("data") or {}
+    metrics = data.get("public_metrics") or {}
+    created = _parse_datetime(data.get("created_at"))
+    age_days = None
+    if created:
+        age_days = (datetime.now(timezone.utc) - created).days
+
+    return norm_ok("twitter", data, {
+        "id": data.get("id"),
+        "username": data.get("username") or username,
+        "display_name": data.get("name"),
+        "followers": metrics.get("followers_count"),
+        "following": metrics.get("following_count"),
+        "tweets": metrics.get("tweet_count"),
+        "listed": metrics.get("listed_count"),
+        "verified": data.get("verified"),
+        "has_bio": bool(data.get("description")),
+        "has_profile_image": bool(data.get("profile_image_url")),
+        "protected": data.get("protected"),
+        "account_age_days": age_days,
+    })
+
+
+async def fetch_youtube(channel_id: str | None, handle: str | None, custom_url: str | None, timeout: float):
+    if not YOUTUBE_API_KEY:
+        return error_json(501, "youtube not configured (YOUTUBE_API_KEY missing)")
+
+    params = {"part": "snippet,statistics", "key": YOUTUBE_API_KEY}
+    if channel_id:
+        params["id"] = channel_id
+    elif handle:
+        params["forHandle"] = handle.lstrip("@")
+    elif custom_url:
+        # Resolve custom URLs via the Search endpoint then hydrate details.
+        search_params = {
+            "part": "snippet",
+            "type": "channel",
+            "q": custom_url,
+            "maxResults": 1,
+            "key": YOUTUBE_API_KEY,
+        }
+        async with httpx.AsyncClient(timeout=timeout) as cx:
+            search_resp = await cx.get("https://www.googleapis.com/youtube/v3/search", params=search_params)
+        if search_resp.status_code != 200:
+            return error_json(search_resp.status_code, f"youtube search error: {search_resp.text[:200]}")
+        items = (search_resp.json() or {}).get("items") or []
+        if not items:
+            return error_json(404, "youtube channel not found")
+        params["id"] = items[0]["snippet"]["channelId"]
+    else:
+        return error_json(400, "missing channel_id, handle, or custom_url")
+
+    async with httpx.AsyncClient(timeout=timeout) as cx:
+        resp = await cx.get("https://www.googleapis.com/youtube/v3/channels", params=params)
+    if resp.status_code != 200:
+        return error_json(resp.status_code, f"youtube api error: {resp.text[:200]}")
+
+    payload = resp.json() or {}
+    items = payload.get("items") or []
+    if not items:
+        return error_json(404, "youtube channel not found")
+
+    item = items[0]
+    snippet = item.get("snippet") or {}
+    statistics = item.get("statistics") or {}
+    published = _parse_datetime(snippet.get("publishedAt"))
+    age_days = None
+    if published:
+        age_days = (datetime.now(timezone.utc) - published).days
+
+    subscriber_count = statistics.get("subscriberCount")
+    if statistics.get("hiddenSubscriberCount"):
+        subscriber_count = None
+
+    return norm_ok("youtube", item, {
+        "title": snippet.get("title"),
+        "handle": snippet.get("customUrl") or handle,
+        "has_description": bool(snippet.get("description")),
+        "has_thumbnail": bool((snippet.get("thumbnails") or {}).get("default")),
+        "subscribers": subscriber_count,
+        "views": statistics.get("viewCount"),
+        "videos": statistics.get("videoCount"),
+        "link": f"https://www.youtube.com/channel/{item.get('id')}" if item.get("id") else None,
+        "account_age_days": age_days,
     })

--- a/readme.md
+++ b/readme.md
@@ -48,8 +48,39 @@ pytest -q
 - `GET /social/instagram?user_id=...` (preferred) or `?username=...`
 - `GET /social/facebook?page_id=...` (preferred) or `?username=...`
 - `GET /social/tiktok?username=...`
+- `GET /social/twitter?username=...` or `?user_id=...`
+- `GET /social/youtube?channel_id=...`, `?handle=@...` or `?custom_url=...`
+- `POST /social/assess` – aggregate multiple platforms and return averaged credibility scoring (see below)
 
 - `POST /detect/image`  form-data: `file` upload **or** `url` pointing to a direct image
 
 **Notes:** IG/FB Graph are ID-first. TikTok endpoints are scope/approval-gated.
+
+### Social scoring & new API tokens
+
+Each social endpoint now returns a `metrics` payload containing:
+
+- `score`: heuristically-derived credibility score in `[0, 1]`
+- `components`: transparent breakdown of the scoring inputs
+- `derived`: helpful derived metrics such as follower/following ratios
+- `flags`: warnings like "Account is very new"
+
+`POST /social/assess` accepts a body such as:
+
+```json
+{
+  "instagram": {"user_id": "17841400000000000"},
+  "twitter": {"username": "example"},
+  "youtube": {"handle": "@channel"}
+}
+```
+
+The response merges the individual platform responses, averages the
+available `metrics.score` values and surfaces any warnings across platforms.
+
+Additional environment variables (set locally or in Vercel) enable the extra
+providers:
+
+- `X_BEARER_TOKEN` (or `TWITTER_BEARER_TOKEN`) – Twitter/X API v2 user lookup
+- `YOUTUBE_API_KEY` – YouTube Data API v3 channel lookups
 # Is-SHe-Real

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,24 @@
+from app.metrics import evaluate_signals
+
+
+def test_evaluate_signals_returns_reasonable_score():
+    signals = {
+        "followers": 12000,
+        "following": 600,
+        "account_age_days": 1500,
+        "has_bio": True,
+        "has_website": True,
+        "profile_picture": True,
+        "media_count": 240,
+        "verified": True,
+    }
+
+    metrics = evaluate_signals("instagram", signals)
+    assert 0.0 <= metrics["score"] <= 1.0
+    assert any(component["name"] == "audience_size" for component in metrics["components"])
+    assert metrics["derived"]["audience_size"] == 12000
+
+
+def test_evaluate_signals_flags_small_accounts():
+    metrics = evaluate_signals("twitter", {"followers": 5, "following": 50})
+    assert any("Audience size is extremely small" in flag for flag in metrics["flags"])

--- a/tests/test_social_assess.py
+++ b/tests/test_social_assess.py
@@ -1,0 +1,72 @@
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+
+from app.main import app
+from app.normalize import norm_ok
+
+
+client = TestClient(app)
+
+
+def test_social_assess_combines_platforms(monkeypatch):
+    async def fake_instagram(*_, **__):
+        return norm_ok(
+            "instagram",
+            {"id": "123"},
+            {
+                "followers": 5000,
+                "following": 200,
+                "has_bio": True,
+                "has_website": True,
+                "profile_picture": True,
+                "media_count": 45,
+            },
+        )
+
+    async def fake_twitter(*_, **__):
+        return norm_ok(
+            "twitter",
+            {"id": "abc"},
+            {
+                "followers": 8000,
+                "following": 300,
+                "account_age_days": 2000,
+                "verified": False,
+                "has_bio": True,
+                "has_profile_image": True,
+                "tweets": 1200,
+            },
+        )
+
+    monkeypatch.setattr("app.main.fetch_instagram", fake_instagram)
+    monkeypatch.setattr("app.main.fetch_twitter", fake_twitter)
+    monkeypatch.setattr(
+        "app.main.TOKENS_STATE",
+        lambda: {"instagram": True, "twitter": True, "facebook": False, "tiktok": False, "youtube": False},
+    )
+
+    payload = {
+        "instagram": {"user_id": "123"},
+        "twitter": {"username": "example"},
+    }
+
+    resp = client.post("/social/assess", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert set(data["results"].keys()) == {"instagram", "twitter"}
+    assert data["summary"]["average_score"] is not None
+    assert data["summary"]["tokens"]["instagram"] is True
+
+
+def test_social_assess_handles_platform_errors(monkeypatch):
+    async def boom(*_, **__):
+        raise HTTPException(status_code=429, detail="rate limited")
+
+    monkeypatch.setattr("app.main.fetch_tiktok", boom)
+
+    resp = client.post("/social/assess", json={"tiktok": {"username": "boom"}})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["results"]["tiktok"]["ok"] is False
+    assert any("rate limited" in flag for flag in data["summary"]["flags"])


### PR DESCRIPTION
## Summary
- add a reusable metrics module and include credibility scoring in every social response
- integrate Twitter/X and YouTube data sources plus an aggregated /social/assess endpoint for cross-network analysis
- document new environment variables and cover heuristics with unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd6f8211cc83299a9a306a54cca5fd