### PR TITLE
Fix Vercel runtime version specification

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.py": {
-      "runtime": "vercel-python@3.11"
+      "runtime": "vercel-python@3.11.0"
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- update the Vercel Python runtime version to include a patch segment so deployment accepts it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8b8d55dc8329bb6dcbece3bec840