### PR TITLE
Add OpenAI-powered endpoint to verify social handles

### DIFF
--- a/app/openai_assess.py
+++ b/app/openai_assess.py
@@ -1,0 +1,177 @@
+"""Utilities for scoring social media handles with the OpenAI API."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+from fastapi import HTTPException
+from openai import AsyncOpenAI
+
+
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
+
+
+def get_client() -> AsyncOpenAI | None:
+    """Return an AsyncOpenAI client if the API key is configured."""
+
+    api_key = os.getenv("OPENAI_API_KEY") or ""
+    if not api_key.strip():
+        return None
+    return AsyncOpenAI(api_key=api_key)
+
+
+def _response_schema() -> Dict[str, Any]:
+    """JSON schema instructing the model to return a strict payload."""
+
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "HandleAssessment",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "platform": {
+                        "type": "string",
+                        "description": "Canonical name of the social media platform.",
+                    },
+                    "handle": {
+                        "type": "string",
+                        "description": "Handle or profile identifier that was investigated.",
+                    },
+                    "verdict": {
+                        "type": "string",
+                        "enum": ["likely_real", "likely_fake", "uncertain"],
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                    },
+                    "reasoning": {
+                        "type": "string",
+                        "description": "One paragraph explaining the judgement.",
+                    },
+                    "evidence": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "summary": {"type": "string"},
+                                "url": {
+                                    "type": "string",
+                                    "description": "Source URL that supports the judgement.",
+                                },
+                            },
+                            "required": ["summary"],
+                            "additionalProperties": False,
+                        },
+                        "maxItems": 5,
+                    },
+                },
+                "required": ["verdict", "confidence", "reasoning", "evidence"],
+                "additionalProperties": False,
+            },
+            "strict": True,
+        },
+    }
+
+
+def _extract_json_payload(response: Any) -> Dict[str, Any]:
+    """Pull the structured JSON payload from an OpenAI response object."""
+
+    if hasattr(response, "model_dump"):
+        dumped = response.model_dump()
+    else:
+        dumped = response
+
+    output: List[Dict[str, Any]] = dumped.get("output") or []
+    for item in output:
+        for content in item.get("content", []) or []:
+            ctype = content.get("type")
+            if ctype in {"json", "json_object"} and content.get("json") is not None:
+                return content["json"]
+            text = content.get("text")
+            if ctype == "output_text" and isinstance(text, str):
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+
+    raise ValueError("Unable to extract JSON payload from OpenAI response")
+
+
+async def evaluate_social_handle(
+    *,
+    handle: str,
+    platform: str | None = None,
+    context: str | None = None,
+    model: str | None = None,
+) -> Dict[str, Any]:
+    """Ask OpenAI to research a handle and provide a credibility verdict."""
+
+    client = get_client()
+    if client is None:
+        raise HTTPException(status_code=501, detail="openai not configured (OPENAI_API_KEY missing)")
+
+    model_name = model or DEFAULT_MODEL
+
+    system_prompt = (
+        "You verify whether social media handles represent real individuals or official entities. "
+        "Research the handle using the web search tool and weigh credible evidence before deciding. "
+        "Explain your judgement succinctly."
+    )
+
+    user_prompt = (
+        "Handle to evaluate: {handle}\n"
+        "Platform: {platform}\n"
+        "Additional context: {context}"
+    ).format(
+        handle=handle,
+        platform=platform or "unknown",
+        context=context or "(none provided)",
+    )
+
+    try:
+        response = await client.responses.create(
+            model=model_name,
+            input=[
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": system_prompt}],
+                },
+                {"role": "user", "content": [{"type": "text", "text": user_prompt}]},
+            ],
+            tools=[{"type": "web_search"}],
+            response_format=_response_schema(),
+        )
+    except Exception as exc:  # pragma: no cover - network issues
+        raise HTTPException(status_code=502, detail=f"openai api error: {exc}") from exc
+
+    payload = _extract_json_payload(response)
+
+    verdict = payload.get("verdict")
+    confidence = payload.get("confidence")
+    reasoning = payload.get("reasoning")
+    evidence = payload.get("evidence") or []
+
+    if not isinstance(verdict, str) or not isinstance(confidence, (int, float)):
+        raise HTTPException(status_code=502, detail="openai response missing required fields")
+    if not isinstance(reasoning, str):
+        raise HTTPException(status_code=502, detail="openai response missing reasoning")
+    if not isinstance(evidence, list):
+        raise HTTPException(status_code=502, detail="openai response evidence malformed")
+
+    return {
+        "ok": True,
+        "model": model_name,
+        "platform": payload.get("platform") or platform,
+        "handle": payload.get("handle") or handle,
+        "verdict": verdict,
+        "confidence": confidence,
+        "reasoning": reasoning,
+        "evidence": evidence,
+        "raw": payload,
+    }
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.0.1
 numpy==1.26.4
 Pillow==10.4.0
 python-multipart==0.0.9
+openai==1.50.2

--- a/tests/test_openai_verify.py
+++ b/tests/test_openai_verify.py
@@ -1,0 +1,82 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_social_verify_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    resp = client.post("/social/verify", json={"handle": "example"})
+    assert resp.status_code == 501
+    body = resp.json()
+    assert body["detail"].startswith("openai not configured")
+
+
+def test_social_verify_success(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def model_dump(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, payload):
+            self._payload = payload
+            self.called_with = None
+
+        class _Responses:
+            def __init__(self, outer):
+                self._outer = outer
+
+            async def create(self, **kwargs):
+                self._outer.called_with = kwargs
+                return FakeResponse(self._outer._payload)
+
+        @property
+        def responses(self):
+            return self._Responses(self)
+
+    fake_payload = {
+        "output": [
+            {
+                "content": [
+                    {
+                        "type": "json",
+                        "json": {
+                            "verdict": "likely_real",
+                            "confidence": 0.8,
+                            "reasoning": "Found multiple reputable references.",
+                            "evidence": [
+                                {"summary": "Official site mentions the handle", "url": "https://example.com"}
+                            ],
+                            "platform": "instagram",
+                            "handle": "realperson",
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+
+    fake_client = FakeClient(fake_payload)
+
+    monkeypatch.setattr("app.openai_assess.get_client", lambda: fake_client)
+
+    resp = client.post(
+        "/social/verify",
+        json={"handle": "realperson", "platform": "instagram", "context": "Celebrity"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["verdict"] == "likely_real"
+    assert data["platform"] == "instagram"
+    assert data["handle"] == "realperson"
+    assert data["evidence"][0]["url"] == "https://example.com"


### PR DESCRIPTION
## Summary
- add an OpenAI helper that can research social handles with web search and return structured verdicts
- expose a `/social/verify` endpoint that wires FastAPI to the helper and allows optional context/model overrides
- cover the new behaviour with dedicated tests and include the OpenAI Python SDK in the dependencies

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de8c9257808329a5c33d8364f7385f