### PR TITLE
Add legal policy pages and supporting styles

### DIFF
--- a/daletion/index.html
+++ b/daletion/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Data Deletion Instructions | Is She Real</title>
+  <meta name="description" content="Request deletion of account data, workspace logs, and uploaded media associated with your Is She Real workspace." />
+  <link rel="stylesheet" href="/styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+</head>
+<body class="legal-page">
+  <header class="legal-header">
+    <div class="container legal-header-inner">
+      <a class="logo" href="/" aria-label="Is She Real home">is<samp>she</samp>real</a>
+      <nav class="legal-nav" aria-label="Legal">
+        <a href="/privacy/">Privacy</a>
+        <a href="/tos/">Terms</a>
+        <a href="/daletion/" aria-current="page">Data deletion</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="legal-main">
+    <div class="container legal-content">
+      <p class="breadcrumb"><a href="/">← Back to product overview</a></p>
+      <h1>Data Deletion Instructions</h1>
+      <p class="lead">Updated <time datetime="2024-06-05">June 5, 2024</time>. Follow these steps to remove Is She Real account data, workspace activity, and stored media.</p>
+
+      <section>
+        <h2>Self-service deletion</h2>
+        <ol>
+          <li>Sign in to your workspace and open <strong>Settings → Storage</strong>.</li>
+          <li>Use the <strong>Clear exports</strong> action to remove locally cached reports and downloaded JSON summaries.</li>
+          <li>If you connected your own API endpoint, disable it to prevent future uploads from being forwarded.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Requesting full removal</h2>
+        <p>To delete account information, billing records, and audit logs, submit a request using one of the channels below. Include the workspace slug, the email address of the requester, and whether you need confirmation for compliance filings.</p>
+        <ul>
+          <li>Email: <a href="mailto:privacy@isshereal.com">privacy@isshereal.com</a></li>
+          <li>Support portal: <a href="https://support.isshereal.com">support.isshereal.com</a></li>
+          <li>Secure API: <code>POST https://api.isshereal.com/v1/data-deletion</code> with your admin token</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Processing timeline</h2>
+        <p>We acknowledge requests within 48 hours. Production data is removed from active systems within 7 days and from encrypted backups within 30 days, unless retention is required by law or to resolve an active dispute.</p>
+      </section>
+
+      <section>
+        <h2>Proof of deletion</h2>
+        <p>After processing we provide a signed confirmation listing the data categories removed and the timestamp of completion. You can opt in to receive automated webhook notifications at <code>/compliance/webhooks</code> for future requests.</p>
+      </section>
+
+      <section>
+        <h2>Questions</h2>
+        <p>Contact <a href="mailto:privacy@isshereal.com">privacy@isshereal.com</a> if you have questions about the status of a request or need to pause deletion for legal reasons.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <a class="logo" href="/">is<samp>she</samp>real</a>
+        <p class="muted">Authenticity intelligence rebuilt after studying the best deepfake and trust &amp; safety tools.</p>
+      </div>
+      <div class="footer-links">
+        <a href="/privacy/">Privacy</a>
+        <a href="/tos/">Terms</a>
+        <a href="/daletion/">Data deletion</a>
+        <a href="/">Product overview</a>
+      </div>
+      <div class="footer-meta">
+        <p>&copy; <span id="year"></span> Is She Real. All rights reserved.</p>
+        <p class="muted">Built with FastAPI + modern browser tooling.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -391,6 +391,11 @@
         <a href="#features">Why switch</a>
         <a href="#faq">FAQ</a>
       </div>
+      <div class="footer-links">
+        <a href="/privacy/">Privacy</a>
+        <a href="/tos/">Terms</a>
+        <a href="/daletion/">Data deletion</a>
+      </div>
       <div class="footer-meta">
         <p>&copy; <span id="year"></span> Is She Real. All rights reserved.</p>
         <p class="muted">Built with FastAPI + modern browser tooling.</p>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy | Is She Real</title>
+  <meta name="description" content="Learn how Is She Real handles account, log, and media data across our authenticity analysis workspace." />
+  <link rel="stylesheet" href="/styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+</head>
+<body class="legal-page">
+  <header class="legal-header">
+    <div class="container legal-header-inner">
+      <a class="logo" href="/" aria-label="Is She Real home">is<samp>she</samp>real</a>
+      <nav class="legal-nav" aria-label="Legal">
+        <a href="/privacy/" aria-current="page">Privacy</a>
+        <a href="/tos/">Terms</a>
+        <a href="/daletion/">Data deletion</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="legal-main">
+    <div class="container legal-content">
+      <p class="breadcrumb"><a href="/">← Back to product overview</a></p>
+      <h1>Privacy Policy</h1>
+      <p class="lead">Updated <time datetime="2024-06-05">June 5, 2024</time>. We built Is She Real to keep authenticity investigations fast and transparent while respecting the privacy of the people and organizations being reviewed.</p>
+
+      <section>
+        <h2>Who we are</h2>
+        <p>Is She Real is an authenticity intelligence workspace that blends metadata, language cues, and forensic imagery signals. We operate from the United States and comply with applicable U.S. state privacy laws and the GDPR where it applies.</p>
+      </section>
+
+      <section>
+        <h2>Information we collect</h2>
+        <ul>
+          <li><strong>Account basics.</strong> Email addresses, names, organization details, and authentication metadata collected when you request access or connect single sign-on.</li>
+          <li><strong>Workspace activity.</strong> Audit logs showing when teams run analyses, export reports, or adjust configuration. We record timestamps, the workspace user, and a summary of the action.</li>
+          <li><strong>Uploaded media.</strong> Images submitted to the forensic lab. By default they are processed in the browser and never leave your device. If you connect your own API endpoint we proxy uploads directly to your infrastructure.</li>
+          <li><strong>Service diagnostics.</strong> IP addresses, device information, and event telemetry that help us secure accounts, prevent abuse, and debug the product.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>How we use information</h2>
+        <ul>
+          <li>Provide, secure, and optimize the detection workspace.</li>
+          <li>Deliver support responses, product updates, and incident notifications.</li>
+          <li>Research new authenticity signals while measuring false positives and bias.</li>
+          <li>Comply with legal obligations and enforce our Terms of Service.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Retention and deletion</h2>
+        <p>Account and billing records are stored for the duration of your contract and as required by law. Workspace logs are kept for twelve months unless you request a shorter retention period. You can delete exports and cached reports at any time from the product, and you can submit a formal deletion request using the process described on our <a href="/daletion/">data deletion page</a>.</p>
+      </section>
+
+      <section>
+        <h2>Sharing and transfers</h2>
+        <p>We do not sell customer data. We may share limited personal data with processors that provide hosting, security, billing, email delivery, and analytics. Whenever data leaves your chosen region we use Standard Contractual Clauses or an equivalent safeguard.</p>
+      </section>
+
+      <section>
+        <h2>Your rights</h2>
+        <p>Depending on your location, you may have the right to access, correct, delete, or restrict processing of your personal data, as well as the right to portability and to object to certain uses. Submit requests to <a href="mailto:privacy@isshereal.com">privacy@isshereal.com</a>. We verify identity before fulfilling a request and respond within 30 days.</p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>Email <a href="mailto:privacy@isshereal.com">privacy@isshereal.com</a> for privacy questions or complaints. If we cannot resolve an issue, you may contact your local data protection authority.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <a class="logo" href="/">is<samp>she</samp>real</a>
+        <p class="muted">Authenticity intelligence rebuilt after studying the best deepfake and trust &amp; safety tools.</p>
+      </div>
+      <div class="footer-links">
+        <a href="/privacy/">Privacy</a>
+        <a href="/tos/">Terms</a>
+        <a href="/daletion/">Data deletion</a>
+        <a href="/">Product overview</a>
+      </div>
+      <div class="footer-meta">
+        <p>&copy; <span id="year"></span> Is She Real. All rights reserved.</p>
+        <p class="muted">Built with FastAPI + modern browser tooling.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,14 @@ body::before {
   z-index: -1;
 }
 
+body.legal-page {
+  background: #f8fafc;
+}
+
+body.legal-page::before {
+  display: none;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -868,6 +876,104 @@ pre {
   font-size: 14px;
 }
 
+.legal-header {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 24px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.legal-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.legal-nav {
+  display: flex;
+  gap: 16px;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.legal-nav a {
+  color: rgba(241, 245, 249, 0.88);
+}
+
+.legal-nav a[aria-current="page"] {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.legal-main {
+  padding: 64px 0 96px;
+}
+
+.legal-content {
+  background: #ffffff;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  padding: 48px;
+  display: grid;
+  gap: 28px;
+}
+
+.legal-content h1 {
+  margin: 0;
+  font-size: clamp(32px, 2.4vw + 18px, 44px);
+}
+
+.legal-content .lead {
+  font-size: 18px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.legal-content section {
+  display: grid;
+  gap: 12px;
+}
+
+.legal-content section h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.legal-content ul,
+.legal-content ol {
+  margin: 0;
+  padding-left: 22px;
+  color: var(--muted);
+}
+
+.legal-content li {
+  margin-bottom: 8px;
+}
+
+.legal-content li:last-child {
+  margin-bottom: 0;
+}
+
+.legal-content code {
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 13px;
+  background: #f1f5f9;
+  border-radius: 8px;
+  padding: 2px 6px;
+}
+
+.breadcrumb {
+  margin: 0 0 -12px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.breadcrumb a {
+  color: inherit;
+}
+
 /* Animations */
 .reveal {
   opacity: 0;
@@ -968,6 +1074,16 @@ pre {
   }
   .hero-actions .btn {
     width: 100%;
+  }
+  .legal-header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .legal-nav {
+    flex-wrap: wrap;
+  }
+  .legal-content {
+    padding: 32px 24px;
   }
 }
 

--- a/tos/index.html
+++ b/tos/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Terms of Service | Is She Real</title>
+  <meta name="description" content="Read the Terms of Service that govern your use of the Is She Real authenticity intelligence workspace and API." />
+  <link rel="stylesheet" href="/styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+</head>
+<body class="legal-page">
+  <header class="legal-header">
+    <div class="container legal-header-inner">
+      <a class="logo" href="/" aria-label="Is She Real home">is<samp>she</samp>real</a>
+      <nav class="legal-nav" aria-label="Legal">
+        <a href="/privacy/">Privacy</a>
+        <a href="/tos/" aria-current="page">Terms</a>
+        <a href="/daletion/">Data deletion</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="legal-main">
+    <div class="container legal-content">
+      <p class="breadcrumb"><a href="/">← Back to product overview</a></p>
+      <h1>Terms of Service</h1>
+      <p class="lead">Effective <time datetime="2024-06-05">June 5, 2024</time>. These Terms of Service describe the contract between you (the customer) and Is She Real regarding access to our authenticity analysis workspace, APIs, and related services.</p>
+
+      <section>
+        <h2>1. Acceptance</h2>
+        <p>By creating an account, signing an order form, or using the product, you agree to these Terms and our <a href="/privacy/">Privacy Policy</a>. If you are using the services on behalf of an organization you confirm that you have authority to bind that organization.</p>
+      </section>
+
+      <section>
+        <h2>2. Services</h2>
+        <p>We provide hosted software to analyze online personas, domains, and media files. We may add, change, or remove features with reasonable notice. Beta or preview functionality is provided “as is” and may be discontinued at any time.</p>
+      </section>
+
+      <section>
+        <h2>3. Customer responsibilities</h2>
+        <ul>
+          <li>Maintain the confidentiality of your account credentials and API keys.</li>
+          <li>Ensure that submitted content is lawful and that you have the right to analyze it.</li>
+          <li>Use the product in compliance with applicable laws, platform policies, and industry regulations.</li>
+          <li>Promptly notify us of any unauthorized use or security incident involving your workspace.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>4. Usage limits and suspension</h2>
+        <p>We may rate-limit or suspend access if you exceed documented API limits, impact platform stability, or violate these Terms. We will make reasonable efforts to notify you in advance unless doing so would risk the security or integrity of the service.</p>
+      </section>
+
+      <section>
+        <h2>5. Intellectual property</h2>
+        <p>The Is She Real name, branding, documentation, and software are owned by us and licensed—not sold—to you. You retain ownership of the content you submit. You grant us a limited license to process that content solely to provide the services.</p>
+      </section>
+
+      <section>
+        <h2>6. Payment</h2>
+        <p>Fees are invoiced as specified on an order form or in your online account. Unless stated otherwise, payments are due within 30 days of invoice. Late payments may accrue interest at 1.5% per month (or the maximum allowed by law) and we may suspend access for accounts that are 30 days past due.</p>
+      </section>
+
+      <section>
+        <h2>7. Confidentiality</h2>
+        <p>Each party agrees to protect the other party’s confidential information with the same care it uses for its own. Confidential information includes non-public product details, security documentation, pricing, and detection results.</p>
+      </section>
+
+      <section>
+        <h2>8. Warranties and disclaimers</h2>
+        <p>We warrant that we will provide the services in a professional manner and that we own or have the rights to provide the software. Except for the foregoing, the services are provided “as is” without warranties of accuracy, fitness for a particular purpose, or non-infringement.</p>
+      </section>
+
+      <section>
+        <h2>9. Liability</h2>
+        <p>Our aggregate liability under these Terms is limited to the fees you paid to us in the twelve months prior to the event giving rise to the claim. Neither party is liable for indirect, incidental, consequential, or punitive damages.</p>
+      </section>
+
+      <section>
+        <h2>10. Term and termination</h2>
+        <p>These Terms remain in effect until your subscription ends or is terminated. Either party may terminate for uncured material breach with 30 days’ notice. Upon termination you must stop using the services and request data deletion if desired.</p>
+      </section>
+
+      <section>
+        <h2>11. Governing law</h2>
+        <p>These Terms are governed by the laws of the State of New York, excluding conflict of law principles. The parties agree to the exclusive jurisdiction of state and federal courts located in New York County, New York.</p>
+      </section>
+
+      <section>
+        <h2>12. Contact</h2>
+        <p>Questions about these Terms can be sent to <a href="mailto:legal@isshereal.com">legal@isshereal.com</a>. Contract notices should be addressed to Is She Real, Attn: Legal, 228 Park Ave S, PMB 70724, New York, NY 10003.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <a class="logo" href="/">is<samp>she</samp>real</a>
+        <p class="muted">Authenticity intelligence rebuilt after studying the best deepfake and trust &amp; safety tools.</p>
+      </div>
+      <div class="footer-links">
+        <a href="/privacy/">Privacy</a>
+        <a href="/tos/">Terms</a>
+        <a href="/daletion/">Data deletion</a>
+        <a href="/">Product overview</a>
+      </div>
+      <div class="footer-meta">
+        <p>&copy; <span id="year"></span> Is She Real. All rights reserved.</p>
+        <p class="muted">Built with FastAPI + modern browser tooling.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated privacy, terms of service, and data deletion pages to satisfy Facebook app submission requirements
- create shared legal page styling and responsive tweaks for the new content
- expose links to the legal pages in the site footer for easy discovery

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dea4e8a7f083299f01196cff888bfc