### PR TITLE
fix: use supported python runtime for vercel functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.py": {
-      "runtime": "vercel-python@3.11.0"
+      "runtime": "python3.11"
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- update the Vercel function configuration to use the official python3.11 runtime instead of the unpublished vercel-python package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec2b37ad08329a2c7cf43164946c5